### PR TITLE
converter: fix NPE

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/bridge/api/converter/HostedPaymentPageFormDescriptorResultConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/bridge/api/converter/HostedPaymentPageFormDescriptorResultConverter.java
@@ -19,15 +19,15 @@ package org.killbill.billing.plugin.bridge.api.converter;
 
 import org.killbill.billing.payment.plugin.api.HostedPaymentPageFormDescriptor;
 import org.killbill.billing.plugin.api.payment.PluginHostedPaymentPageFormDescriptor;
-import org.killbill.billing.plugin.bridge.api.BridgePaymentPluginApi;
 
 public class HostedPaymentPageFormDescriptorResultConverter implements ResultConverter<org.killbill.billing.client.model.HostedPaymentPageFormDescriptor, HostedPaymentPageFormDescriptor> {
+
     @Override
     public HostedPaymentPageFormDescriptor convertModelToApi(final org.killbill.billing.client.model.HostedPaymentPageFormDescriptor desc) {
-        return new PluginHostedPaymentPageFormDescriptor(desc.getKbAccountId(),
-                desc.getFormUrl(),
-                desc.getFormMethod(),
-                ConverterHelper.convertToApiPluginProperties(desc.getFormFields()),
-                ConverterHelper.convertToApiPluginProperties(desc.getProperties()));
+        return desc == null ? null : new PluginHostedPaymentPageFormDescriptor(desc.getKbAccountId(),
+                                                                               desc.getFormUrl(),
+                                                                               desc.getFormMethod(),
+                                                                               ConverterHelper.convertToApiPluginProperties(desc.getFormFields()),
+                                                                               ConverterHelper.convertToApiPluginProperties(desc.getProperties()));
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/bridge/api/converter/PaymentMethodInfoPluginResultConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/bridge/api/converter/PaymentMethodInfoPluginResultConverter.java
@@ -17,23 +17,24 @@
 
 package org.killbill.billing.plugin.bridge.api.converter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.killbill.billing.client.model.PaymentMethods;
 import org.killbill.billing.payment.plugin.api.PaymentMethodInfoPlugin;
 import org.killbill.billing.plugin.api.payment.PluginPaymentMethodInfoPlugin;
-import org.killbill.billing.plugin.bridge.api.BridgePaymentPluginApi;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.google.common.collect.ImmutableList;
 
 public class PaymentMethodInfoPluginResultConverter implements ResultConverter<PaymentMethods, List<PaymentMethodInfoPlugin>> {
 
     @Override
     public List<PaymentMethodInfoPlugin> convertModelToApi(final PaymentMethods paymentMethods) {
-        return paymentMethods.stream()
-                .map(pm -> new PluginPaymentMethodInfoPlugin(pm.getAccountId(),
-                        pm.getPaymentMethodId(),
-                        pm.getIsDefault(),
-                        pm.getPluginInfo().getExternalPaymentMethodId()))
-                .collect(Collectors.toList());
+        return paymentMethods == null ? ImmutableList.<PaymentMethodInfoPlugin>of() : paymentMethods.stream()
+                                                                                                    .map(pm -> new PluginPaymentMethodInfoPlugin(pm.getAccountId(),
+                                                                                                                                                 pm.getPaymentMethodId(),
+                                                                                                                                                 pm.getIsDefault(),
+                                                                                                                                                 pm.getPluginInfo().getExternalPaymentMethodId()))
+                                                                                                    .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/bridge/api/converter/PaymentTransactionInfoPluginListResultConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/bridge/api/converter/PaymentTransactionInfoPluginListResultConverter.java
@@ -17,18 +17,24 @@
 
 package org.killbill.billing.plugin.bridge.api.converter;
 
-import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
-
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+
+import com.google.common.collect.ImmutableList;
 
 public class PaymentTransactionInfoPluginListResultConverter implements ResultConverter<org.killbill.billing.client.model.Payment, List<PaymentTransactionInfoPlugin>> {
 
     @Override
     public List<PaymentTransactionInfoPlugin> convertModelToApi(final org.killbill.billing.client.model.Payment payment) {
-        return payment.getTransactions()
-                .stream()
-                .map(targetTransaction -> new PaymentTransactionInfoPluginResultConverter().convertModelToApi(targetTransaction))
-                .collect(Collectors.toList());
+        if (payment == null || payment.getTransactions() == null) {
+            return ImmutableList.<PaymentTransactionInfoPlugin>of();
+        } else {
+            return payment.getTransactions()
+                          .stream()
+                          .map(targetTransaction -> new PaymentTransactionInfoPluginResultConverter().convertModelToApi(targetTransaction))
+                          .collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/bridge/api/converter/PaymentTransactionInfoPluginResultConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/bridge/api/converter/PaymentTransactionInfoPluginResultConverter.java
@@ -22,25 +22,24 @@ import org.killbill.billing.client.model.PaymentTransaction;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
 import org.killbill.billing.plugin.api.payment.PluginPaymentTransactionInfoPlugin;
-import org.killbill.billing.plugin.bridge.api.BridgePaymentPluginApi;
 
 public class PaymentTransactionInfoPluginResultConverter implements ResultConverter<PaymentTransaction, PaymentTransactionInfoPlugin> {
 
     @Override
     public PaymentTransactionInfoPlugin convertModelToApi(final PaymentTransaction paymentTransaction) {
-        return new PluginPaymentTransactionInfoPlugin(paymentTransaction.getPaymentId(),
-                paymentTransaction.getTransactionId(),
-                TransactionType.valueOf(paymentTransaction.getTransactionType()),
-                paymentTransaction.getAmount(),
-                Currency.valueOf(paymentTransaction.getCurrency()),
-                ConverterHelper.toPluginStatus(paymentTransaction.getStatus()),
-                paymentTransaction.getGatewayErrorMsg(),
-                paymentTransaction.getGatewayErrorCode(),
-                paymentTransaction.getFirstPaymentReferenceId(),
-                paymentTransaction.getSecondPaymentReferenceId(),
-                paymentTransaction.getEffectiveDate(),
-                paymentTransaction.getEffectiveDate(),
-                ConverterHelper.convertToApiPluginProperties(paymentTransaction.getProperties()));
+        return paymentTransaction == null ? null : new PluginPaymentTransactionInfoPlugin(paymentTransaction.getPaymentId(),
+                                                                                          paymentTransaction.getTransactionId(),
+                                                                                          TransactionType.valueOf(paymentTransaction.getTransactionType()),
+                                                                                          paymentTransaction.getAmount(),
+                                                                                          Currency.valueOf(paymentTransaction.getCurrency()),
+                                                                                          ConverterHelper.toPluginStatus(paymentTransaction.getStatus()),
+                                                                                          paymentTransaction.getGatewayErrorMsg(),
+                                                                                          paymentTransaction.getGatewayErrorCode(),
+                                                                                          paymentTransaction.getFirstPaymentReferenceId(),
+                                                                                          paymentTransaction.getSecondPaymentReferenceId(),
+                                                                                          paymentTransaction.getEffectiveDate(),
+                                                                                          paymentTransaction.getEffectiveDate(),
+                                                                                          ConverterHelper.convertToApiPluginProperties(paymentTransaction.getProperties()));
 
     }
 }


### PR DESCRIPTION
Seen in a test system:

```
Caused by: java.lang.NullPointerException: null
    at org.killbill.billing.plugin.bridge.api.converter.PaymentTransactionInfoPluginListResultConverter.convertModelToApi(PaymentTransactionInfoPluginListResultConverter.java:29)
    at org.killbill.billing.plugin.bridge.api.converter.PaymentTransactionInfoPluginListResultConverter.convertModelToApi(PaymentTransactionInfoPluginListResultConverter.java:25)
    at org.killbill.billing.plugin.bridge.api.BridgePaymentPluginApi.internalGenericPaymentTransactionOperation(BridgePaymentPluginApi.java:416)
    at org.killbill.billing.plugin.bridge.api.BridgePaymentPluginApi.getPaymentInfo(BridgePaymentPluginApi.java:139)
```
