### PR TITLE
converter: return the last matching transaction

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/bridge/api/converter/ConverterHelper.java
+++ b/src/main/java/org/killbill/billing/plugin/bridge/api/converter/ConverterHelper.java
@@ -96,7 +96,7 @@ public class ConverterHelper {
         if (transactions != null && !transactions.isEmpty()) {
             result = transactions.stream().filter(paymentTransaction -> (kbTransactionExternalKey != null && paymentTransaction.getTransactionExternalKey().equals(kbTransactionExternalKey)))
                     //.peek(paymentTransaction -> System.err.println(String.format(".... transactionId ='%s'", paymentTransaction.getTransactionId())))
-                    .collect(Collectors.collectingAndThen(Collectors.toList(), paymentTransactions -> paymentTransactions.isEmpty() ? transactions.get(transactions.size() - 1) : paymentTransactions.get(0)));
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), paymentTransactions -> paymentTransactions.isEmpty() ? transactions.get(transactions.size() - 1) : paymentTransactions.get(paymentTransactions.size() - 1)));
         }
         return Optional.ofNullable(result);
     }


### PR DESCRIPTION
When payments are retried, KB_P will return an ordered list of transactions with the same external key.
